### PR TITLE
Pre compute of highest compatible version

### DIFF
--- a/portalwire/api.go
+++ b/portalwire/api.go
@@ -479,10 +479,7 @@ func (p *PortalProtocolAPI) Offer(enr string, contentItems [][2]string) (string,
 		return "", err
 	}
 
-	version, err := p.portalProtocol.getHighestVersion(n)
-	if err != nil {
-		return "", err
-	}
+	version := p.portalProtocol.table.getNodeHighestVersion(n)
 	// transfer bitlist to []byte
 	if version == 0 {
 		accept = p.portalProtocol.handleV0Offer(accept)

--- a/portalwire/portal_protocol.go
+++ b/portalwire/portal_protocol.go
@@ -1266,14 +1266,7 @@ func (p *PortalProtocol) handleFindContent(n *enode.Node, addr *net.UDPAddr, req
 
 					writeCtx, writeCancel := context.WithTimeout(bctx, defaultUTPWriteTimeout)
 					defer writeCancel()
-					content, err = p.encodeUtpContent(n, content)
-					if err != nil {
-						if metrics.Enabled() {
-							p.portalMetrics.utpOutFailConn.Inc(1)
-						}
-						p.Log.Error("encode utp content failed", "err", err)
-						return
-					}
+					content = p.encodeUtpContent(n, content)
 					var n int
 					n, err = conn.Write(writeCtx, content)
 					conn.Close()

--- a/portalwire/portal_protocol_v1.go
+++ b/portalwire/portal_protocol_v1.go
@@ -215,13 +215,13 @@ func (p *PortalProtocol) decodeUtpContent(target *enode.Node, data []byte) ([]by
 	return data, nil
 }
 
-func (p *PortalProtocol) encodeUtpContent(target *enode.Node, data []byte) ([]byte, error) {
+func (p *PortalProtocol) encodeUtpContent(target *enode.Node, data []byte) []byte {
 	version := p.table.getNodeHighestVersion(target)
 	if version == 1 {
 		contentLen := uint32(len(data))
 		contentLenBytes := leb128.EncodeUint32(contentLen)
 		contentLenBytes = append(contentLenBytes, data...)
-		return contentLenBytes, nil
+		return contentLenBytes
 	}
-	return data, nil
+	return data
 }

--- a/portalwire/table.go
+++ b/portalwire/table.go
@@ -199,7 +199,7 @@ func (tab *Table) getNode(id enode.ID) *enode.Node {
 	return nil
 }
 
-// getNodeHighestVersion returns the node higest compatible version
+// getNodeHighestVersion returns the node highest compatible version
 func (tab *Table) getNodeHighestVersion(node *enode.Node) uint8 {
 	tab.mutex.Lock()
 	defer tab.mutex.Unlock()
@@ -207,7 +207,7 @@ func (tab *Table) getNodeHighestVersion(node *enode.Node) uint8 {
 	return tab.currentVersions.getHighestVersion(node)
 }
 
-// updateNodeHighestVersion updates/set the node higest compatible version
+// updateNodeHighestVersion updates/set the node highest compatible version
 func (tab *Table) updateNodeHighestVersion(node *enode.Node) {
 	tab.mutex.Lock()
 	defer tab.mutex.Unlock()

--- a/portalwire/versions.go
+++ b/portalwire/versions.go
@@ -1,0 +1,117 @@
+package portalwire
+
+import (
+	"errors"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+type protocolVersions []uint8
+
+func (pv protocolVersions) ENRKey() string { return "pv" }
+
+var Versions protocolVersions = protocolVersions{0, 1} //protocol network versions defined here
+
+const expiryMinutes = 5 // expiry time in minutes
+
+// maxCompatibleVersionSize ideally should have the buckets plus the replacement Buckets size
+const maxCompatibleVersionSize = nBuckets * (bucketSize + maxReplacements)
+
+type activeVersions struct {
+	currentVersions protocolVersions          //versions implemented currently
+	highestVersion  map[*enode.Node]uint8     //map nodes highest compatible version
+	expireTime      map[*enode.Node]time.Time //map nodes with expiry time
+	count           int                       //count nodes stored
+	log             log.Logger
+}
+
+func newActiveVersions(log log.Logger) *activeVersions {
+	return &activeVersions{
+		currentVersions: Versions,
+		highestVersion:  make(map[*enode.Node]uint8),
+		expireTime:      make(map[*enode.Node]time.Time),
+		count:           0,
+		log:             log,
+	}
+}
+
+func (av *activeVersions) getHighestVersion(node *enode.Node) uint8 {
+	//if the node is not mapped, or its mapping is expired update highest version
+	_, mapped := av.highestVersion[node]
+	if !mapped || time.Now().After(av.expireTime[node]) {
+		av.updateHighestVersion(node)
+	}
+
+	return av.highestVersion[node]
+}
+
+func (av *activeVersions) updateHighestVersion(node *enode.Node) {
+	//check mapping count to prevent memory leak
+	_, mapped := av.highestVersion[node]
+	if av.count == maxCompatibleVersionSize && !mapped {
+		av.log.Debug("highest compatible version mapping full, can not update", "node", node.String())
+		return
+	} else if !mapped {
+		av.count++
+	}
+
+	versions := &protocolVersions{}
+	av.expireTime[node] = time.Now().Add(time.Minute * time.Duration(expiryMinutes))
+
+	err := node.Load(versions)
+	// if any error, assumes version default 0
+	if err != nil {
+		av.highestVersion[node] = 0
+		av.log.Debug("could not determine highest compatible version, will use 0", "node", node.String(), "err", err)
+		return
+	}
+
+	av.highestVersion[node], err = findBiggestSameNumber(av.currentVersions, *versions)
+	if err != nil {
+		av.log.Debug("error on highest version number", "node", node.String(), "err", err)
+	}
+}
+
+func (av *activeVersions) deleteHighestVersion(node *enode.Node) {
+	_, mapped := av.highestVersion[node]
+	if mapped {
+		av.count--
+		delete(av.highestVersion, node)
+		delete(av.expireTime, node)
+	}
+}
+
+// findTheBiggestSameNumber finds the largest value that exists in both slices.
+// Returns the largest common value, or an error if there are no common values.
+func findBiggestSameNumber(a []uint8, b []uint8) (uint8, error) {
+	if len(a) == 0 || len(b) == 0 {
+		return 0, errors.New("empty slice provided")
+	}
+
+	// Create a map to track values in the first slice
+	valuesInA := make(map[uint8]bool)
+	for _, val := range a {
+		valuesInA[val] = true
+	}
+
+	// Find common values and track the maximum
+	var maxCommon uint8
+	foundCommon := false
+
+	for _, val := range b {
+		if valuesInA[val] {
+			foundCommon = true
+			if val > maxCommon {
+				maxCommon = val
+			}
+		}
+	}
+
+	if !foundCommon {
+		return 0, errors.New("no common values found")
+	}
+
+	return maxCommon, nil
+}


### PR DESCRIPTION
Fixes https://github.com/zen-eth/shisui/issues/96

Summary

* `Versions` var and all stuff related to versioning moved to versions.go
* the structure `activeVersions` in versions.go stores a map of nodes and the respective highest compatible version, with auxiliary information
* on `handleTalkRequest` the highest compatible version is updated/created
* after the expiration time of 5 minutes, the highest compatible version is updated with the current enr
* map size is limited to the size of buckets (`nBuckets * (bucketSize + maxReplacements)`) to prevent memory leak
* versions is managed by `Table`, that deletes or stores `highestVersion` as nodes are added or removed from buckets, this prevents an infinitely growing higherVersion map.