### PR TITLE
closes #106

### DIFF
--- a/portalwire/common.go
+++ b/portalwire/common.go
@@ -17,16 +17,16 @@
 package portalwire
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	crand "crypto/rand"
 	"encoding/binary"
+	"errors"
 	"math/rand"
 	"net"
 	"net/netip"
 	"sync"
 	"time"
-	"bytes"
-	"errors"
 
 	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/log"
@@ -35,7 +35,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/netutil"
 	"github.com/tetratelabs/wabin/leb128"
 )
-
 
 // UDPConn is a network connection on which discovery can operate.
 type UDPConn interface {
@@ -152,12 +151,12 @@ func decodeSingleContent(data []byte) (content []byte, remaining []byte, err err
 	if err != nil {
 		return nil, data, err
 	}
-	
+
 	headerSize := int(bytesRead)
 	if len(data) < headerSize+int(contentLen) {
 		return nil, data, errors.New("insufficient data for content length")
 	}
-	
+
 	content = data[headerSize : headerSize+int(contentLen)]
 	remaining = data[headerSize+int(contentLen):]
 	return content, remaining, nil

--- a/portalwire/common_test.go
+++ b/portalwire/common_test.go
@@ -1,0 +1,47 @@
+package portalwire
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEncodeDecodeSingleContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+	}{
+		{"EmptyContent", []byte{}},
+		{"ShortContent", []byte("hello")},
+		{"BinaryContent", []byte{0x01, 0x02, 0x03, 0xFF}},
+		{"LargeContent", bytes.Repeat([]byte{0xAA}, 1024)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded := encodeSingleContent(tt.content)
+			decoded, remaining, err := decodeSingleContent(encoded)
+			if err != nil {
+				t.Fatalf("decodeSingleContent failed: %v", err)
+			}
+			if !bytes.Equal(decoded, tt.content) {
+				t.Errorf("decoded content mismatch. got %v, want %v", decoded, tt.content)
+			}
+			if len(remaining) != 0 {
+				t.Errorf("expected no remaining bytes, got %v", remaining)
+			}
+		})
+	}
+}
+
+func TestDecodeSingleContent_InvalidData(t *testing.T) {
+	data := encodeSingleContent([]byte("incomplete"))
+	if len(data) < 2 {
+		t.Fatalf("encoded data too short for this test")
+	}
+	corrupted := data[:len(data)-2]
+
+	_, _, err := decodeSingleContent(corrupted)
+	if err == nil {
+		t.Error("expected error for insufficient data, got nil")
+	}
+}

--- a/portalwire/portal_protocol.go
+++ b/portalwire/portal_protocol.go
@@ -1997,7 +1997,7 @@ func encodeContents(contents [][]byte) []byte {
 func decodeContents(payload []byte) ([][]byte, error) {
 	contents := make([][]byte, 0)
 	remainingData := payload
-	
+
 	for len(remainingData) > 0 {
 		content, remaining, err := decodeSingleContent(remainingData)
 		if err != nil {
@@ -2008,7 +2008,6 @@ func decodeContents(payload []byte) ([][]byte, error) {
 	}
 	return contents, nil
 }
-
 
 func getContentKeys(request *OfferRequest) [][]byte {
 	switch request.Kind {

--- a/portalwire/portal_protocol_v1.go
+++ b/portalwire/portal_protocol_v1.go
@@ -257,11 +257,11 @@ func (p *PortalProtocol) decodeUtpContent(target *enode.Node, data []byte) ([]by
 		if err != nil {
 			return nil, err
 		}
-		
+
 		if len(remaining) > 0 {
 			return nil, errors.New("content length mismatch")
 		}
-		
+
 		return content, nil
 	}
 	return data, nil


### PR DESCRIPTION
To avoid duplication of code, I created a util function `encodeSingleContent` and `decodeSingleContent` that operates on single content blob. 
`decodeContents` , `encodeContents`  in portal_protocol.go,  and  `encodeUtpContent` , `decodeUtpContent` in portal_protocol_v1.go are refactored to avoid duplicate code.
The util functions  `encodeSingleContent` and `decodeSingleContent` are written in portalwire/common.go.