### PR TITLE
Proposal: requirement of external oracle for history ephemeral

### DIFF
--- a/cmd/shisui/config.go
+++ b/cmd/shisui/config.go
@@ -37,6 +37,8 @@ func getPortalConfig(ctx *cli.Context) (*portal.Config, error) {
 		config.PortalProtocolConfig.ListenAddr = port
 	}
 
+	config.ExternalOracle = ctx.String(utils.PortalExternalOracleFlag.Name)
+
 	trustedBlockRoot := ctx.String(utils.PortalTrustedBlockRootFlag.Name)
 	if trustedBlockRoot != "" {
 		if !strings.HasPrefix(trustedBlockRoot, "0x") && !strings.HasPrefix(trustedBlockRoot, "0X") {

--- a/cmd/shisui/main.go
+++ b/cmd/shisui/main.go
@@ -43,6 +43,7 @@ var (
 		utils.PortalTrustedBlockRootFlag,
 		utils.PortalTableInitFlag,
 		utils.PortalUtpConnSizeLimitFlag,
+		utils.PortalExternalOracleFlag,
 	}
 	historyRpcFlags = []cli.Flag{
 		utils.PortalRPCListenAddrFlag,
@@ -113,6 +114,8 @@ func shisui(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	utils.VerifyExternalOracle(config)
 
 	// Start metrics export if enabled
 	utils.SetupMetrics(config.Metrics)

--- a/cmd/shisui/utils/flags.go
+++ b/cmd/shisui/utils/flags.go
@@ -216,7 +216,7 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 // verify availability of external oracle for history
 func VerifyExternalOracle(config *portal.Config) {
 	if slices.Contains(config.Networks, portalwire.History.Name()) {
-		if !slices.Contains(config.Networks, portalwire.Beacon.Name()) && !(len(config.ExternalOracle) > 0) {
+		if !slices.Contains(config.Networks, portalwire.Beacon.Name()) && len(config.ExternalOracle) <= 0 {
 			Fatalf("History sub network require or beacon network or an external oracle provided")
 		}
 	}

--- a/cmd/shisui/utils/flags.go
+++ b/cmd/shisui/utils/flags.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/metrics/influxdb"
 	"github.com/urfave/cli/v2"
 	"github.com/zen-eth/shisui/internal/flags"
+	"github.com/zen-eth/shisui/portal"
 	"github.com/zen-eth/shisui/portalwire"
 )
 
@@ -178,7 +180,7 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Name:     "networks",
 		Usage:    "Portal sub networks: history, beacon, state",
 		Category: flags.PortalNetworkCategory,
-		Value:    cli.NewStringSlice(portalwire.History.Name()),
+		Value:    cli.NewStringSlice(portalwire.History.Name(), portalwire.Beacon.Name()),
 	}
 	PortalDiscv5GnetFlag = &cli.BoolFlag{
 		Name:     "discv5.gnet",
@@ -204,7 +206,21 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Value:    portalwire.DefaultUtpConnSize,
 		Category: flags.PortalNetworkCategory,
 	}
+	PortalExternalOracleFlag = &cli.StringFlag{
+		Name:     "external.oracle",
+		Usage:    "External oracle for knowing the HEAD of the history chain",
+		Category: flags.PortalNetworkCategory,
+	}
 )
+
+// verify availability of external oracle for history
+func VerifyExternalOracle(config *portal.Config) {
+	if slices.Contains(config.Networks, portalwire.History.Name()) {
+		if !slices.Contains(config.Networks, portalwire.Beacon.Name()) && !(len(config.ExternalOracle) > 0) {
+			Fatalf("History sub network require or beacon network or an external oracle provided")
+		}
+	}
+}
 
 func SetupMetrics(cfg *metrics.Config) {
 	if !cfg.Enabled {

--- a/portal/node.go
+++ b/portal/node.go
@@ -42,6 +42,7 @@ type Config struct {
 	Networks              []string
 	Metrics               *metrics.Config
 	DisableTableInitCheck bool
+	ExternalOracle        string
 }
 
 func DefaultConfig() *Config {


### PR DESCRIPTION
This PR create a flag `--external.oracle` of type `string` (for use with `addr:port`).

This PR replace the default value of flag `--networks` for the value `["history", "beacon"]`

This PR implements the logic: If history sub network is running, must be informed ***OR*** an external oracle ***OR*** must be using bacon sub network.

In case none of the above, it exits with message:
>"History sub network require or beacon network or an external oracle provided"

### Rationalle

Since history ephemerals requires an external oracle (external or beacon sub network), this is a step in the implementation of ephemerals.

This is al alternative to the approach of require both history+beacon and consider a possible set up with external oracle.